### PR TITLE
4 loki plex

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: yjohnsondev
 name: homelab_alloy
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.0
+version: 1.1.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/plex/README.md
+++ b/roles/plex/README.md
@@ -1,0 +1,114 @@
+# `homelab_alloy.plex`
+
+> [!WARNING]
+> Plex Media Server is very chatty, even with debug logging disabled. Additionally, it sets logs as `WARN` or `ERROR` often, even if they have no immediate or direct impact to the user.
+>
+> For example, "keep alive" signals from connected clients show up as `WARN` logs because the server logs them as `Ignoring unexpected message in NotificationStream`.
+>
+> Because these quirks are undocumented and could therefore be changed at any moment, this role does not filter nor drop any logs. If using Grafana, I recommend using `Deduplication: Signature` on the logs so they don't get flooded with irrelevant messages.
+>
+## Description
+
+This role creates `loki.source.file` and `loki.process` components that read and process Plex Media Server logs. It does so by scraping the log files from the standard Plex directory on a variable interval, as defined by `loki.source.file`'s arguments.
+
+```mermaid
+---
+title: Example of pipeline
+---
+
+flowchart TD
+
+subgraph ".../plex.loki.alloy"
+ lsf
+ lp
+end
+
+subgraph "Defined elsewhere..."
+ direction LR
+ lr1
+ lr2
+end
+
+subgraph Filesystem
+direction BT
+fs1(.../Plex Media Server.log)
+fs2(.../Plex Media Scanner Deep Analysis.log)
+end
+
+lsf ==targets===> Filesystem
+lsf(loki.source.file) --"forward_to"--> lp(loki.process)
+lp --"forward_to"--> lr1(Loki-compatible receiver)
+lp --"forward_to"--> lr2(Loki-compatible receiver)
+```
+
+## Example Playbook
+
+This is the minimal playbook required to run this role.
+
+```yaml
+- name: Run homelab_alloy
+  hosts: all
+  become: true
+  roles:
+ - role: yjohnsondev.homelab_alloy.plex
+   vars:
+        plex_loki_receiver_list:
+          - "loki.write.default.receiver"
+```
+
+## All Variables
+
+> [!NOTE]
+> You can set the `config_name` variable to change the name of the config file itself. It will be added as "`{{ config_name }}.loki.alloy`" if provided, otherwise it will be added as "`write.loki.alloy`. **This must to be added as a variable for the role and not the play**, otherwise every subsequent role will overwrite it.
+
+The only required variable is `plex_loki_receiver_list`, which is added to the `loki.process`'s `forward_to` argument.
+
+```yaml
+plex_loki_receiver_list:      # `list(string)`
+ # Example
+ # - "loki.write.default.receiver"
+```
+
+### Component labels
+
+> [!INFO]
+> Additional options for `loki.source.file` can be found in `templates/README.md`
+
+```yaml
+# Optional
+plex_loki_source_file_label:  # Default: 'plex_source'
+plex_loki_process_label:      # Default: 'plex_process'
+```
+
+### Labels appended to log entries
+
+```yaml
+# Optional
+plex_loki_appname:       # Default: 'plexmediaserver'
+plex_loki_instance:      # Default: Value of ansible_hostname
+plex_loki_environment:   # Default: 'default'
+plex_loki_network:       # Default: 'default'
+```
+
+### Logs
+
+```yaml
+# Optional
+plex_loki_logs_dir:
+# Default: '/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Logs'
+
+plex_loki_logs:
+# Default
+#  - Plex Media Server
+#  - Plex Tuner Service
+#  - Plex Media Scanner Chapter Thumbnails
+#  - Plex Media Scanner Credits
+#  - Plex Media Scanner Deep Analysis
+#  - Plex Media Scanner Matcher
+#  - Plex Media Scanner Voice Activity
+```
+
+## Relevant Documentation
+
+- [Plex Media Server Logs | Plex Support](https://support.plex.tv/articles/200250417-plex-media-server-log-files/)
+- [Where is the Plex Media Server data directory located? | Plex Support](https://support.plex.tv/articles/202915258-where-is-the-plex-media-server-data-directory-located/)

--- a/roles/plex/defaults/main.yaml
+++ b/roles/plex/defaults/main.yaml
@@ -1,4 +1,6 @@
-plex_logs:
+plex_loki_source_file_label: "plex_source"
+plex_loki_process_label: "plex_process"
+plex_loki_logs:
   - Plex Media Server
   - Plex Tuner Service
   - Plex Media Scanner Chapter Thumbnails
@@ -7,7 +9,7 @@ plex_logs:
   - Plex Media Scanner Matcher
   - Plex Media Scanner Voice Activity
 
-plex_logs_dir: /var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Logs
+plex_loki_logs_dir: /var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Logs
 
 # __loki_source_file_comment_header: Plex Logs
 # __loki_source_file_label: plex_logs_files

--- a/roles/plex/defaults/main.yaml
+++ b/roles/plex/defaults/main.yaml
@@ -1,0 +1,26 @@
+plex_logs:
+  - Plex Media Server
+  - Plex Tuner Service
+  - Plex Media Scanner Chapter Thumbnails
+  - Plex Media Scanner Credits
+  - Plex Media Scanner Deep Analysis
+  - Plex Media Scanner Matcher
+  - Plex Media Scanner Voice Activity
+
+plex_logs_dir: /var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Logs
+
+# __loki_source_file_comment_header: Plex Logs
+# __loki_source_file_label: plex_logs_files
+# __loki_source_file_path_list:
+# __loki_source_file_target_labels_dict:
+# __loki_source_file_receiver_list:
+# __loki_source_file_encoding:
+# __loki_source_file_legacy_positions_file:
+# __loki_source_file_tail_from_end:
+# __loki_source_file_decompression:
+# __loki_source_file_decompression_enabled:
+# __loki_source_file_decompression_format:
+# __loki_source_file_decompression_initial_delay:
+__loki_source_file_file_watch: true
+# __loki_source_file_file_watch_max_poll_frequency:
+__loki_source_file_file_watch_min_poll_frequency: "1m"

--- a/roles/plex/meta/main.yaml
+++ b/roles/plex/meta/main.yaml
@@ -1,3 +1,2 @@
 dependencies:
   - role: common
-  - role: __local_file

--- a/roles/plex/meta/main.yaml
+++ b/roles/plex/meta/main.yaml
@@ -1,0 +1,3 @@
+dependencies:
+  - role: common
+  - role: __local_file

--- a/roles/plex/tasks/main.yaml
+++ b/roles/plex/tasks/main.yaml
@@ -1,0 +1,18 @@
+- name: Generate local file components
+  ansible.builtin.set_fact:
+    loki_source_file_components: '{{ lookup("template", "__loki_source_file.j2") }}'
+  vars:
+    __loki_source_file_comment_header: "Plex Media Server Logs"
+    __loki_source_file_label: "plex"
+    __loki_source_file_path_list: "{{ [plex_logs_dir] | product(plex_logs) | map('join', '/') | product(['.log']) | map('join') | list }}"
+    __loki_source_file_receiver_list:
+      - "loki.process.{{ plex_loki_process_label }}.receiver"
+
+- name: Generate configuration file from template
+  ansible.builtin.template:
+    src: plex.loki.alloy.j2
+    dest: /tmp/test
+    mode: ''
+
+  # ansible.builtin.debug:
+  #   msg: "{{ lookup('ansible.builtin.template', '__local_file.j2') }}"

--- a/roles/plex/tasks/main.yaml
+++ b/roles/plex/tasks/main.yaml
@@ -1,18 +1,28 @@
 - name: Generate local file components
+  # debug:
+  #   msg: "{{__loki_source_file_target_labels_dict}}"
   ansible.builtin.set_fact:
     loki_source_file_components: '{{ lookup("template", "__loki_source_file.j2") }}'
   vars:
     __loki_source_file_comment_header: "Plex Media Server Logs"
-    __loki_source_file_label: "plex"
+    __loki_source_file_label: "plex_source"
+    __loki_source_file_target_labels_dict:
+      job: loki.source.file
+      component: loki.source.file.{{ __loki_source_file_label }}
+      app: "{{ plex_loki_appname | default('plexmediaserver') }}"
+      instance: '{{ plex_loki_instance | default(ansible_hostname) }}'
+      environment: '{{ plex_loki_environment }}'
+      network: '{{ plex_loki_network | default("default") }}'
     __loki_source_file_path_list: "{{ [plex_logs_dir] | product(plex_logs) | map('join', '/') | product(['.log']) | map('join') | list }}"
     __loki_source_file_receiver_list:
       - "loki.process.{{ plex_loki_process_label }}.receiver"
 
 - name: Generate configuration file from template
   ansible.builtin.template:
-    src: plex.loki.alloy.j2
-    dest: /tmp/test
-    mode: ''
-
-  # ansible.builtin.debug:
-  #   msg: "{{ lookup('ansible.builtin.template', '__local_file.j2') }}"
+    src: "{{ role_name }}.loki.alloy.j2"
+    dest: "{{ alloy_dir }}/{{ config_name | default('plex') }}.loki.alloy"
+    mode: "{{ config_permissions }}"
+    owner: "{{ alloy_user }}"
+    group: "{{ alloy_group }}"
+  notify:
+    - Verify Grafana Alloy

--- a/roles/plex/tasks/main.yaml
+++ b/roles/plex/tasks/main.yaml
@@ -1,19 +1,19 @@
-- name: Generate local file components
+- name: Generate loki.file components
   # debug:
   #   msg: "{{__loki_source_file_target_labels_dict}}"
   ansible.builtin.set_fact:
     loki_source_file_components: '{{ lookup("template", "__loki_source_file.j2") }}'
   vars:
     __loki_source_file_comment_header: "Plex Media Server Logs"
-    __loki_source_file_label: "plex_source"
+    __loki_source_file_label: "{{ plex_loki_source_file_label }}"
     __loki_source_file_target_labels_dict:
       job: loki.source.file
       component: loki.source.file.{{ __loki_source_file_label }}
       app: "{{ plex_loki_appname | default('plexmediaserver') }}"
       instance: '{{ plex_loki_instance | default(ansible_hostname) }}'
-      environment: '{{ plex_loki_environment }}'
+      environment: '{{ plex_loki_environment | default("default") }}'
       network: '{{ plex_loki_network | default("default") }}'
-    __loki_source_file_path_list: "{{ [plex_logs_dir] | product(plex_logs) | map('join', '/') | product(['.log']) | map('join') | list }}"
+    __loki_source_file_path_list: "{{ [plex_loki_logs_dir] | product(plex_loki_logs) | map('join', '/') | product(['.log']) | map('join') | list }}"
     __loki_source_file_receiver_list:
       - "loki.process.{{ plex_loki_process_label }}.receiver"
 

--- a/roles/plex/templates/plex.loki.alloy.j2
+++ b/roles/plex/templates/plex.loki.alloy.j2
@@ -1,0 +1,45 @@
+// MANAGED BY ANSIBLE
+{{ loki_source_file_components }}
+
+loki.process "{{ plex_loki_process_label }}" {
+    forward_to = [
+        {% for receiver in plex_loki_receiver_list %}{{ receiver }},
+        {% endfor +%}
+    ]
+
+    // Separate timestamp from content
+    stage.regex {
+        expression = "^(?P<time>\\w{3} \\d{2}, \\d{4} \\d{2}:\\d{2}:\\d{2}\\.\\d{3}) (?P<content>.*)$"
+    }
+
+    stage.regex {
+        source = "content"
+        expression = "\\[(?P<thread>\\d+)\\] (?P<level>\\w+) - (?P<msg>.*)$"
+    }
+
+    stage.timestamp {
+        source = "time"
+        format = "Jan 02, 2006 15:04:05.000" // Plex timestamp format
+    }
+
+    stage.structured_metadata {
+        values = {
+            msg = "msg",
+            thread_id = "thread",
+        }
+    }
+
+    stage.labels {
+        values = {
+            level = "level",
+        }
+    }
+
+    stage.output {
+        source = "content"
+    }
+
+    stage.drop {
+        older_than = "168h" // 7 days
+    }
+}

--- a/roles/plex/templates/plex.loki.alloy.j2
+++ b/roles/plex/templates/plex.loki.alloy.j2
@@ -38,8 +38,4 @@ loki.process "{{ plex_loki_process_label }}" {
     stage.output {
         source = "content"
     }
-
-    stage.drop {
-        older_than = "168h" // 7 days
-    }
 }

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,19 @@
+# Templates
+
+## `__local_file.j2`
+
+Example:
+
+```yaml
+- name: Generate local file components
+  ansible.builtin.set_fact:
+    local_file_templates: "{{ local_file_templates | default('') + lookup('template', '__local_file.j2') }}"
+  vars:
+    __local_file_comment_header: '{{ item }}'
+    __local_file_label: '{{ item | replace(" ", "_") | lower }}'
+    __local_file_path: '{{ plex_logs_dir + "/" + item + ".log" }}'
+    __local_file_detector: '{{ local_file_detector }}'
+    __local_file_poll_frequency: '{{ local_file_poll_frequency }}'
+    __local_file_is_secret: '{{ local_file_is_secret }}'
+  loop: '{{ plex_logs }}'
+```

--- a/templates/README.md
+++ b/templates/README.md
@@ -43,4 +43,3 @@ __loki_source_file_file_watch:                    # Boolean, required if other r
 __loki_source_file_file_watch_max_poll_frequency: # String
 __loki_source_file_file_watch_min_poll_frequency: # String
 ```
-

--- a/templates/README.md
+++ b/templates/README.md
@@ -17,3 +17,30 @@ Example:
     __local_file_is_secret: '{{ local_file_is_secret }}'
   loop: '{{ plex_logs }}'
 ```
+
+## `__loki_source_file.j2`
+
+Variables:
+
+```yaml
+__loki_source_file_comment_header:                # Optional, preppended to the template
+
+__loki_source_file_label:                         # Required
+__loki_source_file_path_list:                     # List of strings, where each string is the absolute path to the file to log
+__loki_source_file_target_labels_dict:            # Optional, defines the labels to be appended to loglines for the given path
+__loki_source_file_receiver_list:                 # Required, must be in the format of loki.<COMPONENT>.<LABEL>.receiver
+
+__loki_source_file_encoding:                      # String, see docs
+__loki_source_file_legacy_positions_file:         # String
+__loki_source_file_tail_from_end:                 # Boolean
+
+__loki_source_file_decompression:                 # Boolean, required if other related settings are used 
+__loki_source_file_decompression_enabled:         # Boolean
+__loki_source_file_decompression_format:          # String, see docs
+__loki_source_file_decompression_initial_delay:   # String
+
+__loki_source_file_file_watch:                    # Boolean, required if other related settings are used
+__loki_source_file_file_watch_max_poll_frequency: # String
+__loki_source_file_file_watch_min_poll_frequency: # String
+```
+

--- a/templates/__local_file.j2
+++ b/templates/__local_file.j2
@@ -1,0 +1,10 @@
+{# https://grafana.com/docs/alloy/latest/reference/components/local/local.file/ #}
+// {{ __local_file_comment_header }}
+local.file "{{ __local_file_label }}" {
+  filename = "{{ __local_file_path }}"
+  {% if __local_file_detector is defined and __local_file_detector %}detector = "{{ __local_file_detector }}"{% endif %}
+
+  {% if __local_file_poll_frequency is defined and __local_file_poll_frequency %}poll_frequency = "{{ __local_file_poll_frequency }}"{% endif %}
+
+  {% if __local_file_is_secret is defined %}is_secret = {{ __local_file_is_secret | lower }}{% endif %}
+}

--- a/templates/__loki_source_file.j2
+++ b/templates/__loki_source_file.j2
@@ -1,7 +1,9 @@
+//
 // {{ __loki_source_file_comment_header }}
+//
 loki.source.file "{{ __loki_source_file_label }}" {
     targets = [
-        {% for path in __loki_source_file_path_list %}{__path__ = "{{ path }}",{% if __loki_source_file_target_labels_dict is defined %}{% for item in __loki_source_file_target_labels_dict %}{% for key,value in item.items() %} {{key}} = "{{value}}",{% endfor %}{% endfor %}{% endif +%}},
+        {% for path in __loki_source_file_path_list %}{__path__ = "{{ path }}", source = "{{ path | basename }}", {% if __loki_source_file_target_labels_dict %}{% for item in __loki_source_file_target_labels_dict|dict2items %} {{item.key}} = "{{item.value}}",{% endfor %}{% endif +%}},
         {% endfor +%}
     ]
     forward_to = [

--- a/templates/__loki_source_file.j2
+++ b/templates/__loki_source_file.j2
@@ -1,0 +1,29 @@
+// {{ __loki_source_file_comment_header }}
+loki.source.file "{{ __loki_source_file_label }}" {
+    targets = [
+        {% for path in __loki_source_file_path_list %}{__path__ = "{{ path }}",{% if __loki_source_file_target_labels_dict is defined %}{% for item in __loki_source_file_target_labels_dict %}{% for key,value in item.items() %} {{key}} = "{{value}}",{% endfor %}{% endfor %}{% endif +%}},
+        {% endfor +%}
+    ]
+    forward_to = [
+        {% for receiver in __loki_source_file_receiver_list %}{{ receiver }},
+        {% endfor +%}
+    ]
+
+    {% if __loki_source_file_encoding is defined and __loki_source_file_encoding %}encoding = "{{ __loki_source_file_encoding }}"{% endif %}
+
+    {% if __loki_source_file_legacy_positions_file is defined and __loki_source_file_legacy_positions_file %}legacy_positions_file = "{{ __loki_source_file_legacy_positions_file }}"{% endif %}
+    
+    {% if __loki_source_file_tail_from_end is defined and __loki_source_file_tail_from_end %}tail_from_end = {{ __loki_source_file_legacy_positions_file | lower }}{% endif %}
+
+    {% if __loki_source_file_decompression is defined and __loki_source_file_decompression -%}decompression {
+        enabled = {{ __loki_source_file_decompression_enabled | lower }}
+        format = "{{ __loki_source_file_decompression_format }}"
+        {% if __loki_source_file_decompression_initial_delay is defined %}initial_delay = "{{ __loki_source_file_decompression_initial_delay }}"{% endif %}
+    }{%- endif %}
+
+    {% if __loki_source_file_file_watch is defined and __loki_source_file_file_watch -%}file_watch {
+        {% if __loki_source_file_file_watch_max_poll_frequency is defined %}max_poll_frequency = "{{__loki_source_file_file_watch_max_poll_frequency}}"{% endif +%}
+        {% if __loki_source_file_file_watch_min_poll_frequency is defined %}min_poll_frequency = "{{__loki_source_file_file_watch_min_poll_frequency}}"{% endif +%}
+    }{% endif %}
+
+}


### PR DESCRIPTION
Closes #4 

This merge adds `plex` as a role, which creates a configuration file for Alloy with two components. It has no breaking changes with current code, but it does introduce the `templates/` directory with Jinja2 templates that can be reused for later roles. Of note is the `loki_source_file.j2`, which supports all the configuration options present for the component.

The expectation is that this role is used with Plex Media Server hosts, but since this can be installed in a myriad of ways, there are variables that can be modified to change the behavior of this role. See the role's README for details.